### PR TITLE
Extract GB transmission availability from PDF

### DIFF
--- a/config/gb-model/config.common.yaml
+++ b/config/gb-model/config.common.yaml
@@ -5,6 +5,7 @@
 
 urls:
   gb-etys-boundaries: https://api.neso.energy/dataset/997f4820-1ad4-499b-b1fe-4b8d3d7fbc72/resource/e914fcec-1dc9-4f1f-97e7-59c0d9521bea/download/etys-boundary-gis-data-mar25.zip
+  transmission-availability: https://www.neso.energy/document/211021/download
 target_crs: "EPSG:27700"
 area_loss_tolerance_percent: 0.01 # percentage of area loss tolerated when splitting regions
 min_region_area: 1000000 # minimum area of a region in square meters (1 km²) for keeping it after splitting

--- a/envs/gb-model/workflow.yaml
+++ b/envs/gb-model/workflow.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: pypsa-eur
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- python>=3.10
+- pip
+
+# Inhouse packages
+- pypsa>=0.32.1
+- atlite>=0.3
+- linopy>=0.4.4
+- powerplantmatching>=0.5.15
+
+# Dependencies of the workflow itself
+- curl
+- pdfplumber=0.9.0
+- numpy
+- pandas>=2.1
+- geopandas>=1
+- xarray>=2024.03.0,<2025.07.0
+

--- a/envs/shell.yaml
+++ b/envs/shell.yaml
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText:  gb-open-market-model contributors
-#
-# SPDX-License-Identifier: CC0-1.0
-
-name: shell
-channels:
-  - conda-forge
-dependencies:
-  - curl

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: gb-open-market-model contributors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+software-deployment-method: conda
+cores: 1

--- a/rules/gb-model.smk
+++ b/rules/gb-model.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText:  gb-open-market-model contributors
+# SPDX-FileCopyrightText: gb-open-market-model contributors
 #
 # SPDX-License-Identifier: MIT
 
@@ -8,6 +8,7 @@ import subprocess
 from zipfile import ZipFile
 from pathlib import Path
 
+
 configfile: "config/gb-model/config.common.yaml"
 
 
@@ -16,28 +17,29 @@ rule retrieve_etys_boundary_data:
     output:
         boundary_shp="data/gb-model/etys-boundary-gis-data.zip",
     params:
-        url=config["urls"]["gb-etys-boundaries"]
+        url=config["urls"]["gb-etys-boundaries"],
     log:
-        logs("retrieve_etys_boundary_data.log")
-    resources:
-        mem_mb=1000,
-    conda: "../envs/shell.yaml"  # This is required to install `curl` into a conda env on Windows 
-    shell: "curl -sSLvo {output} {params.url}"
+        logs("retrieve_etys_boundary_data.log"),
+    localrule: True
+    conda:
+        "../envs/gb-model/workflow.yaml"
+    shell:
+        "curl -sSLvo {output} {params.url}"
 
 
 # Rule to create region shapes using create_region_shapes.py
 rule create_region_shapes:
     input:
         country_shapes=resources("country_shapes.geojson"),
-        etys_boundary_lines="data/gb-model/etys-boundary-gis-data.zip",
+        etys_boundary_lines=rules.retrieve_etys_boundary_data.output.boundary_shp,
     output:
-        raw_region_shapes=resources("raw_region_shapes.geojson")
+        raw_region_shapes=resources("raw_region_shapes.geojson"),
     log:
-        logs("raw_region_shapes.log")
+        logs("raw_region_shapes.log"),
     resources:
         mem_mb=1000,
     conda:
-        "../envs/environment.yaml"
+        "../envs/gb-model/workflow.yaml"
     script:
         "../scripts/gb-model/create_region_shapes.py"
 
@@ -45,14 +47,41 @@ rule create_region_shapes:
 # Rule to manually merge raw_region_shapes
 rule manual_region_merger:
     input:
-        raw_region_shapes=resources("raw_region_shapes.geojson"),
+        raw_region_shapes=rules.create_region_shapes.output.raw_region_shapes,
     output:
         merged_shapes=resources("merged_shapes.geojson"),
     log:
-        logs("manual_region_merger.log")
+        logs("manual_region_merger.log"),
     resources:
         mem_mb=1000,
     conda:
-        "../envs/environment.yaml"
+        "../envs/gb-model/workflow.yaml"
     script:
         "../scripts/gb-model/manual_region_merger.py"
+
+
+rule download_transmission_availability_pdf:
+    output:
+        pdf_report="data/gb-model/transmission-availability.pdf",
+    params:
+        url=config["urls"]["transmission-availability"],
+    log:
+        logs("transmission_availability.log"),
+    localrule: True
+    conda:
+        "../envs/gb-model/workflow.yaml"
+    shell:
+        "curl -sSLvo {output} {params.url}"
+
+
+rule extract_transmission_availability:
+    input:
+        pdf_report=rules.download_transmission_availability_pdf.output.pdf_report,
+    output:
+        csv=resources("transmission_availability.csv"),
+    log:
+        logs("extract_transmission_availability.log"),
+    conda:
+        "../envs/gb-model/workflow.yaml"
+    script:
+        "../scripts/gb-model/extract_transmission_availability.py"

--- a/scripts/gb-model/extract_transmission_availability.py
+++ b/scripts/gb-model/extract_transmission_availability.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText:  gb-open-market-model contributors
+#
+# SPDX-License-Identifier: MIT
+
+
+"""
+PDF table extractor for monthly transmission availability data from NESO reports.
+"""
+
+import logging
+
+import pandas as pd
+import pdfplumber
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+
+def extract_transmission_availability(pdf_path: str) -> pd.DataFrame:
+    """
+    Extract monthly transmission availability data table from a NESO PDF report.
+
+    Args:
+        pdf_path (str): Path to the PDF report.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the extracted transmission availability data.
+    """
+    availability_data = {}
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            tables = page.extract_tables(
+                {
+                    "vertical_strategy": "lines_strict",
+                    "horizontal_strategy": "lines_strict",
+                }
+            )
+            for table in tables:
+                try:
+                    title = table[0][0].lower()
+                except IndexError:
+                    continue
+
+                if (
+                    title.startswith("planned and unplanned unavailability (%)")
+                    and "reactive" not in title
+                ):
+                    df = pd.DataFrame(table[1:]).set_index(0).rename_axis(index="month")
+                    df = (
+                        df.rename(columns=df.iloc[0].str.replace("\n", " "))
+                        .drop("", errors="ignore")
+                        .astype(float)
+                    )
+                    geography = page.extract_text_lines(layout=True)[0]["text"]
+                    availability_data[geography] = df
+                    logger.info(
+                        f"Found monthly availability table for {geography} transmission system with average annual unavailability of {df.Total.mean():.2f}%."
+                    )
+    final_df = pd.concat(
+        availability_data.values(),
+        keys=availability_data.keys(),
+        names=["geography", "month"],
+    )
+    return final_df
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake("extract_transmission_availability")
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    availability_df = extract_transmission_availability(snakemake.input.pdf_report)
+    availability_df.to_csv(snakemake.output.csv)


### PR DESCRIPTION
# Closes #38

## Changes proposed in this Pull Request

- Moved to a shared environment file for all GB rules (`envs/gb-model/workflow.yaml`) (@yerbol-akhmetov I can't test this on your geospatial implementation to ensure all necessary dependencies have been defined since I'm having issues with accessing a JRC API - [this same issue re-emerging](https://github.com/PyPSA/pypsa-eur/issues/1779) - could you check that it still works?).
- Added a snakemake default profile to trigger the use of conda envs when requested and to use one core by default for ease of local testing (@FabianHofmann let me know if there's a different approach you'd prefer we take here).
- Added PDF table extraction script to get availability values for GB transmission.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.