### PR TITLE
Allow for multi-table loading from within same fes sheet

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -445,13 +445,18 @@ fes-sheet-config:
         columns: year
 
     # Annual storage data for 2030 and 2050
+    # SHeet contains multiple tables, one for each scenario
     FL.14:
-      usecols: "P,R,U,X"
+    - usecols: "P,R,U,X"
       skiprows: 58
+      nrows: 6
       index_col: 0
-      header: 0
+      header: [0, 1]
       rename:
-        columns: year
+        columns: [year, parameter]
+        index: name
+      add_index:
+        scenario: leading the way
 
     BB2:
       usecols: "A:E"


### PR DESCRIPTION
I've updated the FES sheet loading config to be able to extract and concatenate multiple tables within a single sheet, to handle the case of FL.14 (and likely other sheets in the workbook).

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
