### PR TITLE
Update endpoint URL

### DIFF
--- a/scripts/gb_model/retrieve_entsoe_unavailability_data.py
+++ b/scripts/gb_model/retrieve_entsoe_unavailability_data.py
@@ -43,7 +43,9 @@ class ENTSOEUnavailabilityAPI:
             api_key: ENTSO-E API key for authentication
         """
         self.api_key = api_key
-        self.base_url = "https://web-api.tp.entsoe.eu/api"
+        self.base_url = os.getenv(
+            "ENTSOE_API_BASE_URL", "https://web-api.tp.entsoe.eu/api"
+        )
         self.session = requests.Session()
         self.rate_limit_delay = 2.0  # Seconds between requests
 


### PR DESCRIPTION
Closes #109 

This requires a user to set a new ENV variable in their `.env` file:

```
ENTSOE_ENDPOINT_URL=https://external-api.tp.entsoe.eu/api
```

The reason I have gone with this approach is that it will work with the enstoe-py package, which is used elsewhere in the workflow (and we could consider using directly for generator unavailability, but it produces a different result and I don't want to spend time working out why).

## Changes proposed in this Pull Request


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
