### PR TITLE
0 -> 1 EV `e_max_pu`

### DIFF
--- a/scripts/gb_model/compose_network.py
+++ b/scripts/gb_model/compose_network.py
@@ -30,10 +30,7 @@ from scripts.add_electricity import (
     attach_hydro,
     flatten,
 )
-from scripts.gb_model._helpers import (
-    get_lines,
-    time_difference_hours,
-)
+from scripts.gb_model._helpers import get_lines, time_difference_hours
 
 logger = logging.getLogger(__name__)
 
@@ -679,7 +676,7 @@ def add_DSR(
             dsr_profile = ev_dsr_profile
             storage_capacity = ev_storage_capacity.MWh
             e_min_pu = dsr_profile.loc[:, df_dsr.index]
-            e_max_pu = 0.0
+            e_max_pu = 1.0
 
         _add_dsr_pypsa_components(
             n, df_dsr, dsr_type, storage_capacity, e_min_pu, e_max_pu


### PR DESCRIPTION
Fixes issue introduced in #133 

@yerbol-akhmetov @SermishaNarayana why do we have an `e_min_pu` for EVs in the first place? Also, we need to set `e_max_pu` to zero at regular intervals to enforce the cyclic nature of DSR for EVs. I don't think this is actually available at the moment. 

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
