### PR TITLE
Add strike price calculation from the low carbon register

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -126,6 +126,16 @@ costs:
     waste PP: Waste-WoodPellets-Waste
     waste CHP: Waste-Gas-Waste CHP
 
+low_carbon_register:
+  carrier_mapping:
+    Offshore Wind: offwind-dc
+    Onshore Wind: onwind
+    Solar PV: solar
+    Energy from Waste: waste
+    Biomass Conversion: biomass
+    Dedicated Biomass: biomass
+
+
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving
 solving:
   options:
@@ -176,6 +186,7 @@ urls:
   gsp-coordinates: https://api.neso.energy/dataset/963525d6-5d83-4448-a99c-663f1c76330a/resource/41fb4ca1-7b59-4fce-b480-b46682f346c9/download/fes2021_regional_breakdown_gsp_info.csv
   eur-supply-table: https://api.neso.energy/dataset/bd83ce0b-7b1e-4ff2-89e8-12d524c34d99/resource/6563801b-6da4-46e7-b147-3d81c0237779/download/fes2023_es2_v001.csv
   etys: https://www.neso.energy/document/223046/download # ETYS November 2021
+  low-carbon-contracts: https://dp.lowcarboncontracts.uk/dataset/5427b55f-cecc-4a72-b3ee-3533cbbd5555/resource/fa730219-fbd2-41b5-9510-ba2b0ff2c1ba/download/actual_cfd_generation_and_avoided_ghg_emissions.csv
 target_crs: "EPSG:27700"
 
 # Manual region merging configuration
@@ -781,7 +792,7 @@ fes-costing-sheet-config:
       columns: year
 
 fes:
-  year_range_incl: [2022, 2041] # 20-year period over which we will run the simulation   
+  year_range_incl: [2022, 2041] # 20-year period over which we will run the simulation
   default_set: PP
   default_characteristics:
     # Ensure all required columns exist with defaults

--- a/doc/gb-model/data_sources.rst
+++ b/doc/gb-model/data_sources.rst
@@ -125,9 +125,16 @@ Energy storage capacity of EVs are obtained by interpolating EV storage data fro
 Storage data is regionally disaggregated based on EV flexibility data.
 Regional distribution of V2G and smart charging flexibility is based on V2G distribution provided in BB1 sheet of FES-2021.
 
--------------------
+------------------------------------
 DSM flexibility for base electricity
--------------------
+------------------------------------
 Demand-side management (DSM) flexibility data for base electricity (residential and I&C) is extracted from the FES-2021 workbook table FLX1.
 Regional distribution of residential demand side response (DSR) flexibility is based on Baseline demand distribution provided in BB1 sheet of FES-2021,
 while regional distribution of services DSR flexibility is based on I&C Flexibility (TouT) distribution provided in BB1 sheet of FES-2021.
+
+-------------------
+Low carbon register
+-------------------
+The `low carbon register <https://www.lowcarboncontracts.uk/our-schemes/contracts-for-difference/register/>`_ provides historical Contracts for Difference (CfD) strike price data.
+We use the average strike price data from all historical years before the first model run year to define the renewable generator offers.
+These are calculated relative to the GB wholesale market price as given by the solved unconstrained model output.

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
 Upcoming Release
 ================
 
+* Process low carbon register CfD strike prices for use in redispatch
 * Define independent DSR hours for each demand type (#144)
 * Disassociate EV DSR and EV V2G components (#140)
 * Add DC links into boundary constraints (#136)

--- a/rules/gb-model.smk
+++ b/rules/gb-model.smk
@@ -745,6 +745,22 @@ rule create_chp_p_min_pu_profile:
         "../scripts/gb_model/create_chp_p_min_pu_profile.py"
 
 
+rule process_CfD_strike_prices:
+    message:
+        "get strike price for low carbon contracts"
+    params:
+        carrier_mapping=config["low_carbon_register"]["carrier_mapping"],
+        end_year=config["fes"]["year_range_incl"][0],
+    input:
+        register="data/gb-model/downloaded/low-carbon-contracts.csv",
+    output:
+        csv=resources("gb-model/CfD_strike_prices.csv"),
+    log:
+        logs("process_CfD_strike_prices.log"),
+    script:
+        "../scripts/gb_model/process_CfD_strike_prices.py"
+
+
 rule assign_costs:
     message:
         "Prepares costs file from technology-data of PyPSA-Eur and FES and assigns to powerplants"

--- a/scripts/gb_model/process_CfD_strike_prices.py
+++ b/scripts/gb_model/process_CfD_strike_prices.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText:  gb-open-market-model contributors
+#
+# SPDX-License-Identifier: MIT
+
+
+"""
+Low carbon contract strike price processor
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+
+def process_strike_prices(
+    df: pd.DataFrame, carrier_mapping: dict, end_year: int
+) -> pd.DataFrame:
+    """
+    Process low carbon contract strike prices to obtain strike prices per technology and year.
+
+    Args:
+        df (pd.DataFrame): Low carbon contracts register data
+        carrier_mapping (dict): Mapping of technology names to PyPSA carriers
+        end_year (int): Final year to process
+    Returns:
+        pd.DataFrame: DataFrame containing average strike prices indexed by carrier
+    """
+    df_filtered = df[
+        (df.Settlement_Date.dt.year < end_year)
+        & (df.Technology.isin(carrier_mapping.keys()))
+    ]
+    df_strike_price = (
+        df_filtered.replace({"Technology": carrier_mapping})
+        .groupby("Technology")["Strike_Price_GBP_Per_MWh"]
+        .mean()
+        .to_frame("strike_price_GBP_per_MWh")
+        .rename_axis(index="carrier")
+    )
+    logger.info("Processed average strike prices:\n%s", df_strike_price)
+    return df_strike_price
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(Path(__file__).stem)
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # Load the file paths
+    df = pd.read_csv(snakemake.input.register, parse_dates=["Settlement_Date"])
+    df_strike_prices = process_strike_prices(
+        df, snakemake.params.carrier_mapping, end_year=int(snakemake.params.end_year)
+    )
+    df_strike_prices.to_csv(snakemake.output.csv)


### PR DESCRIPTION
Realised this didn't have a linked issue but is needed for re-dispatch, to provide a basis for costing renewables.

The strike price should be applied relative to the average wholesale market price (averaged daily for wind and solar, averaged monthly for waste and biomass), so if the strike price < wholesale market price, they would be paid a subsidy, and if strike price > wholesale market price, they would pay a penalty.


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
