### PR TITLE
Add residential heat demand DSR

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -791,6 +791,18 @@ fes-sheet-config:
       rename:
         columns: year
 
+    FL.10:
+    - usecols: "L:AV"
+      skiprows: 60
+      nrows: 5
+      index_col: 0
+      header: 0
+      rename:
+        columns: year
+        index: flex_source
+      add_index:
+        scenario: leading the way
+
     # Annual storage data for 2030 and 2050
     # SHeet contains multiple tables, one for each scenario
     FL.14:
@@ -925,6 +937,14 @@ fes:
         iandc_heat: ["i&c hp demand"]
       heat:
         electrified_heating_technologies: ["Electric resistive", "ASHP", "GSHP"]
+      bus_suffix:
+        baseline_electricity: " Baseline Electricity"
+        residential: " Baseline Electricity"
+        iandc: " Baseline Electricity"
+        ev: " EV"
+        residential_heat: " Residential Heat"
+        iandc_heat: " I&C Heat"
+
 
     flexibility:
       Technology Detail:
@@ -939,11 +959,21 @@ fes:
         residential_dsr: ["baseline demand"]
         iandc_dsr: ["i&c flexibility (tout)"]
         iandc_heat_dsr: ["i&c hp demand"]
+        residential_heat_dsr: ["residential hp demand"]
       dsr_hours:  # hours during which demand-side management can occur (E.g., 5pm-8pm)
+        residential_heat_dsr: [0, 22]
         residential_dsr: [17, 20]
         iandc_dsr: [17, 20]
-        iandc_heat_dsr: [17, 20]
+        iandc_heat_dsr: [0, 22]
         ev_dsr: [8, 6]
+      carrier_suffix:
+        residential: " Baseline Electricity (Residential) DSR"
+        iandc: " Baseline Electricity (I&C) DSR"
+        ev: " EV DSR"
+        residential_heat: " Residential Heat DSR"
+        iandc_heat: " I&C Heat DSR"
+      residential_heat_flex_level: "Peak after flexing by storage heaters, Hybrid HPs, District Heat, and thermal storage"
+
 
   eur:
     scenario: CT & LW    # "Leading the Way" equivalent in the NESO european supply table
@@ -1014,6 +1044,7 @@ fes:
       residential_dsr: "baseline_electricity"
       iandc_dsr: "baseline_electricity"
       iandc_heat_dsr: "iandc_heat"
+      residential_heat_dsr: "residential_heat"
       H2_demand_annual: "H2"
       off_grid_electrolysis_electricity_demand: "H2"
       H2_storage_capacity: "H2"

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -12,6 +12,8 @@ Release Notes
 Upcoming Release
 ================
 
+* Distribute all loads into their own buses with independently linked DSR stores
+* Add residential heat demand DSR, including district heating flexibility (as it cannot be separated)
 * Process low carbon register CfD strike prices for use in redispatch
 * Define independent DSR hours for each demand type (#144)
 * Disassociate EV DSR and EV V2G components (#140)

--- a/rules/gb-model.smk
+++ b/rules/gb-model.smk
@@ -10,10 +10,6 @@ from pathlib import Path
 import numpy as np
 
 
-wildcard_constraints:
-    flexibility_type="|".join(config["fes"]["gb"]["flexibility"]["Technology Detail"]),
-
-
 # Rule to download and extract ETYS boundary data
 rule download_data:
     message:
@@ -463,8 +459,29 @@ rule create_flexibility_table:
         flexibility=resources("gb-model/{flexibility_type}_flexibility.csv"),
     log:
         logs("create_{flexibility_type}_flexibility_table.log"),
+    wildcard_constraints:
+        flexibility_type="|".join(
+            config["fes"]["gb"]["flexibility"]["Technology Detail"]
+        ),
     script:
         "../scripts/gb_model/create_flexibility_table.py"
+
+
+rule create_heat_flexibility_table:
+    message:
+        "Process residential heat demand flexibility from FES workbook"
+    params:
+        scenario=config["fes"]["gb"]["scenario"],
+        year_range=config["fes"]["year_range_incl"],
+        flex_level=config["fes"]["gb"]["flexibility"]["residential_heat_flex_level"],
+    input:
+        flexibility_sheet=resources("gb-model/fes/2021/FL.10.csv"),
+    output:
+        csv=resources("gb-model/residential_heat_dsr_flexibility.csv"),
+    log:
+        logs("create_heat_flexibility_table.log"),
+    script:
+        "../scripts/gb_model/create_heat_flexibility_table.py"
 
 
 rule process_regional_flexibility_table:
@@ -481,6 +498,10 @@ rule process_regional_flexibility_table:
         regional_flexibility=resources("gb-model/regional_{flexibility_type}.csv"),
     log:
         logs("process_regional_{flexibility_type}_flexibility_table.log"),
+    wildcard_constraints:
+        flexibility_type="|".join(
+            config["fes"]["gb"]["flexibility"]["regional_distribution_reference"]
+        ),
     script:
         "../scripts/gb_model/process_regional_flexibility_table.py"
 
@@ -831,6 +852,8 @@ rule compose_network:
         enable_chp=config["chp"]["enable"],
         prune_lines=config["region_operations"]["prune_lines"],
         dsr_hours_dict=config["fes"]["gb"]["flexibility"]["dsr_hours"],
+        load_bus_suffixes=config["fes"]["gb"]["demand"]["bus_suffix"],
+        flex_carrier_suffixes=config["fes"]["gb"]["flexibility"]["carrier_suffix"],
     input:
         unpack(input_profile_tech),
         demands=expand(
@@ -839,7 +862,7 @@ rule compose_network:
         ),
         dsr=expand(
             resources("gb-model/regional_{sector}_dsr_inc_eur.csv"),
-            sector=["residential", "iandc", "iandc_heat", "ev"],
+            sector=["residential", "iandc", "iandc_heat", "ev", "residential_heat"],
         ),
         ev_data=expand(
             resources("gb-model/regional_ev_{ev_data}_inc_eur.csv"),

--- a/scripts/gb_model/compose_network.py
+++ b/scripts/gb_model/compose_network.py
@@ -343,7 +343,9 @@ def process_demand_data(
     return load
 
 
-def add_load(n: pypsa.Network, demands: dict[str, str]):
+def add_load(
+    n: pypsa.Network, demands: dict[str, str], load_bus_suffixes: dict[str, str]
+):
     """
     Add load as a timeseries to PyPSA network
 
@@ -362,21 +364,12 @@ def add_load(n: pypsa.Network, demands: dict[str, str]):
                 "All demand types should start with 'demand_'."
             )
         # Process data for the demand type
-        if demand_type == "ev_demand":
-            add_EV_load(n, demand_path)
-        else:
-            load = pd.read_csv(demand_path, index_col=[0], parse_dates=True)
-            # Add the load to pypsa Network
-            suffix = f" {demand_type.removesuffix('_demand')}"
-            n.add(
-                "Load",
-                load.columns + suffix,
-                bus=load.columns,
-                p_set=load.add_suffix(suffix),
-            )
+        suffix = load_bus_suffixes[demand_type.removesuffix("_demand")]
+        load = pd.read_csv(demand_path, index_col=[0], parse_dates=True)
+        _add_load_bus(n, load, suffix)
 
 
-def add_EV_load(n: pypsa.Network, ev_demand_path: str):
+def _add_load_bus(n: pypsa.Network, load: pd.DataFrame, suffix: str):
     """
     Add EV load as a timeseries to PyPSA network
 
@@ -384,56 +377,50 @@ def add_EV_load(n: pypsa.Network, ev_demand_path: str):
     ----------
     n : pypsa.Network
         Network to finalize
-    ev_demand_path : str
-        Path to EV demand CSV
+    load : pd.DataFrame
+        DataFrame containing load data indexed by time and bus
+    suffix : str
+        Suffix to append to load buses
     """
-    # Compute EV demand profile using demand shape, annual EV demand and peak EV demand
+    # Add load carrier to pypsa Network
+    carrier = suffix.strip()
+    link_carrier = f"{carrier} unmanaged load"
+    n.add("Carrier", carrier)
 
-    ev_demand = pd.read_csv(ev_demand_path, index_col=[0], parse_dates=True)
+    # Add unmanaged load carrier to pypsa Network
+    n.add("Carrier", link_carrier)
 
-    # Add EV carrier to pypsa Network
-    n.add(
-        "Carrier",
-        "EV",
-    )
-
-    # Add EV unmanaged charging carrier to pypsa Network
-    n.add(
-        "Carrier",
-        "EV unmanaged charging",
-    )
-
-    # Add EV bus
+    # Add load bus
     n.add(
         "Bus",
-        ev_demand.columns,
-        suffix=" EV",
-        carrier="EV",
-        x=n.buses.loc[ev_demand.columns].x,
-        y=n.buses.loc[ev_demand.columns].y,
-        country=n.buses.loc[ev_demand.columns].country,
+        load.columns,
+        suffix=suffix,
+        carrier=carrier,
+        x=n.buses.loc[load.columns].x,
+        y=n.buses.loc[load.columns].y,
+        country=n.buses.loc[load.columns].country,
     )
 
-    # Add the EV load to pypsa Network
+    # Add the load to pypsa Network
     n.add(
         "Load",
-        ev_demand.columns,
-        suffix=" EV",
-        bus=ev_demand.columns + " EV",
-        carrier="EV",
-        p_set=ev_demand.add_suffix(" EV"),
+        load.columns,
+        suffix=suffix,
+        bus=load.columns + suffix,
+        carrier=carrier,
+        p_set=load.add_suffix(suffix),
     )
 
-    # Add EV unmanaged charging
+    # Link the load profile to the AC bus
     n.add(
         "Link",
-        ev_demand.columns,
-        suffix=" EV unmanaged charging",
-        bus0=ev_demand.columns,
-        bus1=ev_demand.columns + " EV",
-        p_nom=ev_demand.max(),
+        load.columns,
+        suffix=" " + link_carrier,
+        bus0=load.columns,
+        bus1=load.columns + suffix,
+        p_nom=load.max(),
         efficiency=1.0,
-        carrier="EV unmanaged charging",
+        carrier=link_carrier,
     )
 
 
@@ -581,6 +568,8 @@ def _add_dsr_pypsa_components(
     storage_capacity: pd.DataFrame,
     e_max_pu: pd.DataFrame,
     p_max_pu: pd.DataFrame,
+    load_bus_suffixes: dict[str, str],
+    flex_carrier_suffixes: dict[str, str],
 ):
     """
     Add DSR components for a given sector to PyPSA network
@@ -599,38 +588,29 @@ def _add_dsr_pypsa_components(
             DataFrame containing maximum state of charge as per unit of the store indexed by time and bus
         p_max_pu : pd.DataFrame
             DataFrame containing maximum power availability as per unit of the link indexed by time and bus
+        load_bus_suffixes: dict[str, str]
+            Suffixes to append to load buses
+        flex_carrier_suffixes : dict[str, str]
+            Suffixes to append to flexibility carriers for each flexibility type
     """
-
-    store_carrier = f"{key} DSR"
-    if key == "ev":
-        bus_suffix = " EV"
-    else:
-        bus_suffix = ""
+    load_bus_suffix = load_bus_suffixes[key]
+    dsr_carrier_suffix = flex_carrier_suffixes[key]
 
     # Add the store carrier to the PyPSA network
-    n.add(
-        "Carrier",
-        store_carrier,
-    )
+    n.add("Carrier", dsr_carrier_suffix.strip())
 
     # Add the DSR shift and reverse carriers to the PyPSA network
-    n.add(
-        "Carrier",
-        f"{key} DSR shift",
-    )
+    n.add("Carrier", f"{dsr_carrier_suffix.strip()} shift")
 
-    n.add(
-        "Carrier",
-        f"{key} DSR reverse",
-    )
+    n.add("Carrier", f"{dsr_carrier_suffix.strip()} reverse")
 
     # Create storage buses, links and stores
     # Add the storage bus to the PyPSA network
     n.add(
         "Bus",
         df.index,
-        suffix=f" {store_carrier} bus",
-        carrier=store_carrier,
+        suffix=dsr_carrier_suffix,
+        carrier=dsr_carrier_suffix.strip(),
         x=n.buses.loc[df.index].x,
         y=n.buses.loc[df.index].y,
         country=n.buses.loc[df.index].country,
@@ -640,37 +620,37 @@ def _add_dsr_pypsa_components(
     n.add(
         "Link",
         df.index,
-        suffix=f" {key} DSR",
-        bus0=df.index + bus_suffix,
-        bus1=df.index + f" {store_carrier} bus",
+        suffix=dsr_carrier_suffix,
+        bus0=df.index + load_bus_suffix,
+        bus1=df.index + dsr_carrier_suffix,
         p_nom=df.p_nom.abs(),
         p_max_pu=p_max_pu,
         efficiency=1.0,
-        carrier=f"{key} DSR shift",
+        carrier=f"{dsr_carrier_suffix.strip()} shift",
     )
 
     # Add the DSR link from DSR bus to AC bus to the PyPSA network
     n.add(
         "Link",
         df.index,
-        suffix=f" {key} DSR reverse",
-        bus0=df.index + f" {store_carrier} bus",
-        bus1=df.index + bus_suffix,
+        suffix=f"{dsr_carrier_suffix} reverse",
+        bus0=df.index + dsr_carrier_suffix,
+        bus1=df.index + load_bus_suffix,
         p_nom=df.p_nom.abs(),
         p_max_pu=p_max_pu,
         efficiency=1.0,
-        carrier=f"{key} DSR reverse",
+        carrier=f"{dsr_carrier_suffix.strip()} reverse",
     )
 
     # Add the DSR store to the PyPSA network
     n.add(
         "Store",
         df.index,
-        suffix=f" {store_carrier}",
-        bus=df.index + f" {store_carrier} bus",
+        suffix=dsr_carrier_suffix,
+        bus=df.index + dsr_carrier_suffix,
         e_nom=storage_capacity,
         e_cyclic=True,
-        carrier=store_carrier,
+        carrier=dsr_carrier_suffix.strip(),
         e_max_pu=e_max_pu,
     )
 
@@ -683,6 +663,8 @@ def add_DSR(
     dsr: dict[str, str],
     dsr_hours_dict: dict[str, list],
     ev_availability_profile: pd.DataFrame,
+    load_bus_suffixes: dict[str, str],
+    flex_carrier_suffixes: dict[str, str],
 ):
     """
     Add DSR components for residential, i&c and i&c heat sectors to PyPSA network
@@ -699,6 +681,11 @@ def add_DSR(
             Hours during which demand-side management can occur
         ev_availability_profile : pd.DataFrame
             DataFrame containing EV availability profile indexed by time and bus
+        load_bus_suffixes: dict[str, str]
+            Suffixes to append to load buses for each flexibility type
+        flex_carrier_suffixes : dict[str, str]
+            Suffixes to append to flexibility carriers for each flexibility type
+
     """
     # Iterate through each demand key in the DSR dictionary
     for file, path in dsr.items():
@@ -725,7 +712,14 @@ def add_DSR(
         )
 
         _add_dsr_pypsa_components(
-            n, df_dsr, dsr_type, storage_capacity, e_max_pu, p_max_pu
+            n,
+            df_dsr,
+            dsr_type,
+            storage_capacity,
+            e_max_pu,
+            p_max_pu,
+            load_bus_suffixes,
+            flex_carrier_suffixes,
         )
 
 
@@ -1167,6 +1161,8 @@ def compose_network(
     H2_data: dict[str, Any],
     enable_chp: bool,
     dsr_hours_dict: dict[str, list],
+    load_bus_suffixes: dict[str, str],
+    flex_carrier_suffixes: dict[str, str],
     year: int,
 ) -> None:
     """
@@ -1212,6 +1208,10 @@ def compose_network(
         Dictionary containing DSR flexibility data for baseline and electrified heat
     dsr_hours_dict: dict[str, list]
         DSR hours for each demand type
+    load_bus_suffixes : dict[str, str]
+        Suffixes to append to load buses for each demand type
+    flex_carrier_suffixes : dict[str, str]
+        Suffixes to append to flexibility carriers for each demand type
     enable_chp : bool
         Whether to enable CHP constraints
     year: int
@@ -1261,7 +1261,7 @@ def compose_network(
         )
         attach_chp_constraints(network, chp_p_min_pu)
 
-    add_load(network, demands)
+    add_load(network, demands, load_bus_suffixes)
 
     ev_availability_profile = pd.read_csv(
         ev_data["avail_profile_s_clustered"], index_col=0, parse_dates=True
@@ -1273,6 +1273,8 @@ def compose_network(
         dsr,
         dsr_hours_dict,
         ev_availability_profile,
+        load_bus_suffixes,
+        flex_carrier_suffixes,
     )
 
     add_EV_V2G(
@@ -1335,5 +1337,7 @@ if __name__ == "__main__":
         enable_chp=snakemake.params.enable_chp,
         prune_lines=snakemake.params.prune_lines,
         dsr_hours_dict=snakemake.params.dsr_hours_dict,
+        load_bus_suffixes=snakemake.params.load_bus_suffixes,
+        flex_carrier_suffixes=snakemake.params.flex_carrier_suffixes,
         year=int(snakemake.wildcards.year),
     )

--- a/scripts/gb_model/create_heat_flexibility_table.py
+++ b/scripts/gb_model/create_heat_flexibility_table.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: gb-dispatch-model contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Flexibility data processor.
+
+This script processes required flexibility data from the FES workbook.
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+
+def parse_heat_flexibility_data(
+    flexibility_data: pd.DataFrame,
+    fes_scenario: str,
+    year_range: list[int],
+    flex_level: str,
+):
+    """
+    Parse and extract heat flexibility data from the FES flexibility dataset.
+
+    Args:
+        flexibility_data (pd.DataFrame): DataFrame containing flexibility data with MultiIndex
+                                         ['year', 'flex_source', 'scenario']
+        fes_scenario (str): FES scenario to filter data for (e.g., 'Steady Progression')
+        year_range (list[int]): Slice of years to filter data for (e.g., [2020, 2030])
+        flex_level (str): Flexibility level to use
+    """
+    # Data is stored as timestamps in upstream file, so we convert it here to integer year
+    flexibility_data["year"] = flexibility_data["year"].dt.year
+    flexibility_data_filtered = (
+        flexibility_data.loc[
+            (flexibility_data.scenario.str.lower() == fes_scenario)
+            & (flexibility_data.year.between(*year_range, inclusive="both"))
+        ]
+        .drop("scenario", axis=1)
+        .set_index(["year", "flex_source"])
+    ).data
+
+    peak = flexibility_data_filtered.xs(
+        "Unconstrained peak electricity demand for heat", level="flex_source"
+    )
+    peak_with_flex = flexibility_data_filtered.xs(flex_level, level="flex_source")
+
+    flex = peak - peak_with_flex
+    assert (is_neg := flex >= 0).all(), (
+        f"Flexibility values must be non-negative. Found: {flex[~is_neg]}"
+    )
+    return flex
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(Path(__file__).stem, flexibility_type="fes_ev_dsm")
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # Load the regional gb data file path
+    flexibility_data = pd.read_csv(
+        snakemake.input.flexibility_sheet,
+        parse_dates=["year"],
+    )
+
+    # Parse input data
+    fes_scenario = snakemake.params.scenario
+    year_range = [int(i) for i in snakemake.params.year_range]
+    flex_level = snakemake.params.flex_level
+
+    df_flexibility = parse_heat_flexibility_data(
+        flexibility_data, fes_scenario, year_range, flex_level
+    )
+
+    df_flexibility = (df_flexibility * 1000).to_frame("p_nom")  # Convert GW to MW
+
+    # Write flexibility dataframe to csv file
+    df_flexibility.to_csv(snakemake.output.csv)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
- Residential heat DSR processed from peak shaving capability of all residential heat flexibility mechanisms
- All loads are their own buses with linked DSR (so DSR stores are isolated from each other and it's easier to distinguish between them all in postprocessing)
- Increased DSR hours for heat (24hr, resetting at 23:00) 

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
