### PR TITLE
re-map generator cost names; `gas` -> `engine`; add battery `p_nom`

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -136,14 +136,14 @@ costs:
     "CO2 intensity":
       CCGT: gas
       OCGT: gas
+      engine: gas
       coal: coal
-      gas: gas
       oil: oil
     fuel:
       CCGT: gas
       OCGT: gas
+      engine: gas
       coal: coal
-      gas: gas
       oil: oil
       biomass: biomass
       waste: biomass
@@ -158,8 +158,8 @@ costs:
       biomass CHP: biomass CHP
       coal PP: coal
       coal CHP: central coal CHP
-      gas PP: direct firing gas
-      gas CHP: central gas CHP
+      engine PP: central gas CHP # `direct firing gas` is a better fit but the data is spurious
+      engine CHP: central gas CHP
       geothermal PP: geothermal
       hydrogen turbine PP: central hydrogen CHP
       hydrogen turbine CHP: central hydrogen CHP
@@ -182,17 +182,18 @@ costs:
     biomass PP: Biomass-Biomass
     biomass CHP: Biomass-Biomass CHP
     CCGT PP: Gas-CCGT
-    CCGT CHP: Gas-CCGT # there is no CCGT CHP VOM costs in FES
+    CCGT CHP: Gas-Gas CHP
     coal PP: Coal-Coal
     coal CHP: Coal-Coal CHP
-    gas CHP: Gas-Gas CHP
-    gas PP: Gas-Gas Reciprocating Engines
+    engine CHP: Gas-Gas CHP
+    engine PP: Gas-Gas Reciprocating Engines
     hydro PP: Hydro-Hydro
     hydrogen turbine PP: Low Carbon-Hydrogen
     hydrogen fuel cell PP: Storage-Fuel Cells
     hydrogen turbine CHP: Gas-Gas CHP # there is no hydrogen CHP costs in FES
     marine PP: Marine-Marine
     OCGT PP: Gas-OCGT
+    OCGT CHP: Gas-Gas CHP
     offwind-dc PP: Offshore Wind-Offshore Wind
     oil PP: Other Thermal-Fuel Oil
     onwind PP: Onshore Wind-Onshore Wind
@@ -209,13 +210,14 @@ costs:
     CCGT CHP: Gas-CCGT CHP
     coal PP: Coal-Coal
     coal CHP: Coal-Coal CHP
-    gas CHP: Gas-GT CHP
-    gas PP: Gas-Gas Reciprocating Engines
+    engine PP: Gas-Gas Reciprocating Engines
+    engine CHP: Gas-Engine CHP
+    OCGT PP: Gas-OCGT
+    OCGT CHP: Gas-GT CHP
     hydrogen turbine PP: Low Carbon-Hydrogen
     hydrogen fuel cell PP: Storage-Fuel Cells
     hydrogen turbine CHP: Gas-Gas CHP # there is no hydrogen CHP costs in FES
-    OCGT PP: Gas-OCGT
-    oil PP: Other Thermal-Fuel Oil
+    oil PP: Gasoil-Steam Oil
     waste PP: WoodPellets-Waste
     waste CHP: Gas-Waste CHP
   voll: 6000 #£/MWh - based on `value_of_lost_load` from (https://www.nationalgrid.com/sites/default/files/documents/Long-term%20Market%20and%20Network%20Constraint%20Modelling.pdf)
@@ -251,7 +253,7 @@ electricity:
   extendable_carriers:
     Generator: []
     Store: []
-  conventional_carriers: [nuclear, oil, OCGT, CCGT, gas, coal, waste, geothermal, biomass]
+  conventional_carriers: [nuclear, oil, OCGT, CCGT, engine, coal, waste, geothermal, biomass]
   renewable_carriers: [solar, onwind, offwind-dc, hydro]
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
@@ -910,9 +912,9 @@ fes:
         Hydrogen fuelled generation: hydrogen turbine  # FIXME: something else here?
         Fuel Cells: hydrogen fuel cell
         Marine: marine
-        Non-renewable Engines (Diesel) (non CHP): oil
-        Non-renewable Engines (Gas) (non CHP): gas
-        Non-renewable CHP: gas
+        Non-renewable Engines (Diesel) (non CHP): engine
+        Non-renewable Engines (Gas) (non CHP): engine
+        Non-renewable CHP: CCGT
         Nuclear: nuclear
         OCGTs (non CHP): OCGT
         Offshore-Wind (off-Grid): offwind-dc
@@ -1002,11 +1004,11 @@ fes:
         Waste: waste
       SubType:
         CCS Biomass: biomass
-        CCS Gas: gas
-        CCGT: OCGT
-        Gas CHP: CCGT
+        CCS Gas: CCGT
+        CCGT: CCGT
         OCGT: OCGT
-        Gas Reciprocating Engines: gas
+        GT CHP: OCGT
+        Gas Reciprocating Engines: engine
         Hydrogen: hydrogen turbine # hydrogen-fueled turbine
         Hydrogen CHP: hydrogen turbine # hydrogen-fueled turbine
         Fuel Oil: oil
@@ -1019,6 +1021,8 @@ fes:
         Lignite: lignite
         Lignite CHP: lignite
         Peat CHP: lignite
+        CCGT CHP: CCGT
+        GT CHP: OCGT
         Hydro: hydro
         Reservoir Hydro: hydro
         Reservoir Hydro with pumping: hydro
@@ -1042,6 +1046,7 @@ fes:
         Coal CHP: CHP
         Lignite CHP: CHP
         Peat CHP: CHP
+        Engine CHP: CHP
         Reservoir Hydro with pumping: Store
 
     totals_to_demand_groups:

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -13,7 +13,7 @@ Upcoming Release
 ================
 
 * Calculate interconnector bids and offers (#151)
-* Add config option to unconstrain `p_nom` for each EUR country's most expensive powerplant, instead of using load shedding.
+* Add config option to set load shedding to the most expensive powerplant plus a small delta.
 * Enable custom busmap to prevent incorrect clustering of offshore buses (#159)
 * Fix H2 demands in Europe using TYNDP H2 NT scenario demands (#152)
 * Add bid/offers for generators (#147)

--- a/scripts/gb_model/compose_network.py
+++ b/scripts/gb_model/compose_network.py
@@ -982,6 +982,7 @@ def add_battery_storage(
         all_data_battery.index,
         bus=all_data_battery.bus,
         carrier="Battery Storage",
+        p_nom=all_data_battery.p_nom,
         p_nom_extendable=False,
         marginal_cost=all_data_battery.marginal_cost,
         capital_cost=0,


### PR DESCRIPTION
Various minor fixes based on looking through the network tables as I prep docs.

## Changes proposed in this Pull Request
- batteries had no `p_nom` defined and so had effectively zero `p_nom`
- generators were being mis-assigned costs and efficiencies so the order of marginal costs didn't make sense. I would expect it to be CCGT < CCGT CHP < OCGT < OCGT CHP < reciprocating engine < reciprocating engine CHP < coal < oil. The updated name mapping for costs achieves this.

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
