### PR TITLE
Handle new load shedding components in constrained network prep

### DIFF
--- a/scripts/gb_model/prepare_constrained_network.py
+++ b/scripts/gb_model/prepare_constrained_network.py
@@ -16,6 +16,8 @@ from scripts._helpers import configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
+LOAD_SHEDDING_REGEX = "Load Shedding"
+
 
 def fix_dispatch(
     constrained_network: pypsa.Network, unconstrained_result: pypsa.Network
@@ -33,7 +35,7 @@ def fix_dispatch(
 
     def _process_p_fix(dispatch_t: pd.DataFrame, p_nom: pd.DataFrame):
         p_fix = (dispatch_t / p_nom).round(5).fillna(0)
-        p_fix = p_fix.drop(columns=p_fix.filter(like="load").columns)
+        p_fix = p_fix.loc[:, ~p_fix.columns.str.contains(LOAD_SHEDDING_REGEX)]
 
         return p_fix
 
@@ -130,8 +132,8 @@ def create_up_down_plants(
         if comp.name not in ["Generator", "StorageUnit", "Link"]:
             continue
 
-        g_up = comp.static.copy()
-        g_down = comp.static.copy()
+        g_up = comp.static.loc[~comp.static.index.str.contains(LOAD_SHEDDING_REGEX)]
+        g_down = comp.static.loc[~comp.static.index.str.contains(LOAD_SHEDDING_REGEX)]
 
         if comp.name != "Link":
             # Filter GB plants


### PR DESCRIPTION
I noticed that we were looking for an outdated name for load shedding when preparing the constrained network.

## Changes proposed in this Pull Request


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
