### PR TITLE
Update to latest working FES costing sheet URL

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -277,7 +277,7 @@ urls:
   transmission-availability-2022: https://www.neso.energy/document/267701/download
   fes-2021-workbook: https://www.neso.energy/document/199971/download # FES 2021 workbook
   fes-2023-workbook: https://www.neso.energy/document/283061/download # FES 2023 workbook
-  fes-costing-workbook: https://www.nationalgrideso.com/document/181961/download
+  fes-costing-workbook: https://www.neso.energy/document/181961/download
   dukes-5.11: https://assets.publishing.service.gov.uk/media/688cb64ee8ba9507fc1b0953/DUKES_5.11.xlsx
   gsp-coordinates: https://api.neso.energy/dataset/963525d6-5d83-4448-a99c-663f1c76330a/resource/41fb4ca1-7b59-4fce-b480-b46682f346c9/download/fes2021_regional_breakdown_gsp_info.csv
   eur-supply-table: https://api.neso.energy/dataset/bd83ce0b-7b1e-4ff2-89e8-12d524c34d99/resource/6563801b-6da4-46e7-b147-3d81c0237779/download/fes2023_es2_v001.csv


### PR DESCRIPTION
Fixes issue that @FabianHofmann rolled into a larger separate PR.

Dealing with it here as a micro PR so that we don't get tripped up by it elsewhere.

## Changes proposed in this Pull Request
- new URL (same data) for the FES costing workbook.

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
