### PR TITLE
Fix dispatch custom constraints script method names

### DIFF
--- a/scripts/gb_model/dispatch/custom_constraints.py
+++ b/scripts/gb_model/dispatch/custom_constraints.py
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: MIT
 import logging
 
+import pandas as pd
+import pypsa
+from snakemake.script import Snakemake
+
 logger = logging.getLogger(__name__)
 
 
@@ -12,3 +16,20 @@ def remove_KVL_constraints(n, snapshots, snakemake):
     """
     n.model.remove_constraints("Kirchhoff-Voltage-Law")
     logger.info("Remove KVL constraints from the model")
+
+
+def custom_constraints(
+    n: pypsa.Network,
+    snapshots: pd.Index,
+    snakemake: Snakemake,
+) -> None:
+    """
+    Apply custom constraints to the PyPSA network.
+
+    Args:
+        n (pypsa.Network): The PyPSA network to modify.
+        snapshots (pd.Index): The snapshots of the network.
+        snakemake (snakemake.Snakemake): The snakemake object for parameters and config.
+    """
+    # Apply boundary constraints
+    remove_KVL_constraints(n, snapshots, snakemake)


### PR DESCRIPTION
Hotfix for issue introduced in merging various PRs into latest master.

## Changes proposed in this Pull Request


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
