### PR TITLE
Reduce minimum annual capacity factor for nuclear

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -95,7 +95,7 @@ renewable:
 conventional:
   nuclear:
     max_annual_capacity_factor: 1
-    min_annual_capacity_factor: 0.70
+    min_annual_capacity_factor: 0.50
 
 costs:
   GBP_to_EUR: 1.1632 # average in 2021: https://www.exchangerates.org.uk/GBP-EUR-spot-exchange-rates-history-2021.html#:~:text=This%20is%20the%20British%20Pound,rate%20in%202021%3A%201.1632%20EUR.


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
To avoid infeasibilities, minimum nuclear capacity factor is set to 0.5 instead of 0.7 as earlier.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
