### PR TITLE
Set trust_env for Client Sessions

### DIFF
--- a/scripts/gb_model/redispatch/fetch_bid_offer_data_elexon.py
+++ b/scripts/gb_model/redispatch/fetch_bid_offer_data_elexon.py
@@ -93,7 +93,7 @@ async def get_historical_bod(
 
     current = start
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         while current <= end:
             # There are 48 settlement periods per day - every 30 mins
             for settlement_period in np.arange(1, 49):
@@ -166,7 +166,7 @@ async def fetch_BM_units(
         url = f"{base_url}/reference/bmunits/all"
 
         # Fetch BM unit data
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             df_bmu = await fetch_api_request_data(
                 url, retrieval_message="BMU Unit Data", session=session
             )


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
On the ZIB cluster, proxy settings do not allow the Elexon API requests to be fetched. Setting trust_env = True when initiating Client Sessions help resolve this issue.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
