### PR TITLE
Update region IDs: GB 30 -> GB NI; GB 31 -> GB 30

### DIFF
--- a/config/config.gb.default.yaml
+++ b/config/config.gb.default.yaml
@@ -417,16 +417,16 @@ region_operations:
     TO: SHETL
 
   - id: 30
-    merge: [79, 80, 81, 82]
-    TO: N-IRL
-
-  - id: 31
     merge: [77]
     TO: NGET
 
+  - id: NI
+    merge: [79, 80, 81, 82]
+    TO: N-IRL
+
   # List for merging regions into neighbouring countries
   add_group_to_neighbour:
-    IE: ["GB 30"]
+    IE: ["GB NI"]
 
 etys:
   # ETYS2024 chart data has two valid sheets that can be selected
@@ -594,7 +594,7 @@ etys:
       bus1: 25
     NW1:
     - bus0: 22
-      bus1: 31
+      bus1: 30
   boundaries_links:
     B6:
     - bus0: 23

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
 Unreleased
 ==========
 
+* Switch regions `GB 30` and `GB 31` and rename new `GB 31` to `GB NI` to more explicitly represent the Northern Ireland region.
 * Set line capacities to large number for constrained network to make sure only boundary capabilities are limiting (#241).
 * New config option to enable aggregating the PyPSA network time dimensions, to reduce solve times (#229).
 * Created new OSM pre-built network, available at https://zenodo.org/records/18712831, to include updates made in upstream PyPSA-Eur (incl. ignoring unbuilt lines) (#237).


### PR DESCRIPTION
The NI region gets merged into Ireland early on, so we lose that region from the composed network. This means that, currently, `GB 30` mysteriously doesn't exist in the network. 

This PR makes the NI region more explicit and less likely to cause confusion later on.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
