### PR TITLE
Add manual ETYS caps for final years

### DIFF
--- a/config/config.gb.2024.yaml
+++ b/config/config.gb.2024.yaml
@@ -472,6 +472,9 @@ etys:
       2040: 2440
       2041: 2460
       2042: 2490
+      2043: 2490
+      2044: 2490
+      2045: 2490
 
 # Note: Set ENTSO_E_API_KEY in your .env file or environment variables
 # Register at https://transparency.entsoe.eu/ to get API key


### PR DESCRIPTION
Missing >2042 data for B3b. I have extended it to use the same value beyond 2042.

## Changes proposed in this Pull Request


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
