### PR TITLE
Add config option to disallow carriers from redispatch

### DIFF
--- a/config/config.default.gb.yaml
+++ b/config/config.default.gb.yaml
@@ -1608,6 +1608,7 @@ redispatch:
     years: []
     api_bmu_fuel_map: false
     max_concurrent_requests: 4
+  no_redispatch_carriers: []
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#time_aggregation
 time_aggregation: []

--- a/config/config.gb.2024.yaml
+++ b/config/config.gb.2024.yaml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+# yaml-language-server: $schema=./schema.default.gb.json
+
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name: "GB"
@@ -1196,6 +1198,8 @@ redispatch:
   year_range_incl: [2025, 2044] # 20-year period over which we will run the simulation
   constraint_cost_extra_years: 20
   unconstrain_lines_and_links: true
+  no_redispatch_carriers:
+  - nuclear
   elexon: # Elexon API data
     technology_mapping: # ignoring renewables in mapping as they come from CfD data
       coal: coal

--- a/config/schema.default.gb.json
+++ b/config/schema.default.gb.json
@@ -4418,6 +4418,13 @@
               "type": "integer"
             }
           }
+        },
+        "no_redispatch_carriers": {
+          "description": "List of carriers to exclude from being redispatched.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       }
     },
@@ -16643,6 +16650,13 @@
               "type": "integer"
             }
           }
+        },
+        "no_redispatch_carriers": {
+          "description": "List of carriers to exclude from being redispatched.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       }
     },

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
 Unreleased
 ==========
 
+* Disallow nuclear from being redispatched (#201).
 * Add missing carrier for non-networked electrolysis demand (#242).
 * Capitalise all EV carriers (#243).
 * Fix interconnector capacity plan to align with FES2024 results (with high degree of subjectivity on project choice) (#232).

--- a/rules/gb-model/redispatch.smk
+++ b/rules/gb-model/redispatch.smk
@@ -140,7 +140,10 @@ rule prepare_constrained_network:
     message:
         "Prepare network for constrained optimization"
     params:
-        unconstrain_lines_and_links=config["redispatch"]["unconstrain_lines_and_links"],
+        unconstrain_lines_and_links=config_provider(
+            "redispatch", "unconstrain_lines_and_links"
+        ),
+        no_redispatch_carriers=config_provider("redispatch", "no_redispatch_carriers"),
     input:
         network=resources("networks/{fes_scenario}/composed_clustered/{year}.nc"),
         unconstrained_result=RESULTS

--- a/scripts/gb_model/_update_config.py
+++ b/scripts/gb_model/_update_config.py
@@ -644,6 +644,10 @@ class RedispatchConfig(GBBaseConfig):
     elexon: ElexonConfig = Field(
         description="Elexon API configuration", default_factory=ElexonConfig
     )
+    no_redispatch_carriers: list[str] = Field(
+        default_factory=list,
+        description="List of carriers to exclude from being redispatched.",
+    )
 
     @field_validator("year_range_incl")
     @classmethod

--- a/scripts/gb_model/redispatch/prepare_constrained_network.py
+++ b/scripts/gb_model/redispatch/prepare_constrained_network.py
@@ -124,6 +124,7 @@ def create_up_down_plants(
     renewable_strike_prices: pd.Series,
     interconnector_bid_offer_profile: pd.DataFrame,
     gb_buses: pd.Index,
+    no_redispatch_carriers: list[str],
 ):
     """
     Add generators and storage units components that mimic increase / decrease in dispatch
@@ -142,6 +143,8 @@ def create_up_down_plants(
         Interconnectors bid/offer profile for each interconnector
     gb_buses: pd.Index
         Index of GB buses
+    no_redispatch_carriers: list[str]
+        List of carriers to exclude from being redispatched.
     """
     for comp in constrained_network.components:
         if comp.name not in ["Generator", "StorageUnit", "Link"]:
@@ -155,16 +158,11 @@ def create_up_down_plants(
         g_down = comp.static.loc[~comp.static.index.str.contains(LOAD_SHEDDING_REGEX)]
 
         if comp.name != "Link":
-            # Filter GB plants
-            g_up = g_up.query("bus in @gb_buses and p_nom != 0")
-            g_down = g_down.query("bus in @gb_buses and p_nom != 0")
+            query = "bus in @gb_buses and p_nom != 0 and carrier not in @no_redispatch_carriers"
         else:
-            g_up = g_up.query(
-                "bus0 in @gb_buses and bus1 not in @gb_buses and p_nom != 0"
-            )
-            g_down = g_down.query(
-                "bus0 in @gb_buses and bus1 not in @gb_buses and p_nom != 0"
-            )
+            query = "bus0 in @gb_buses and bus1 not in @gb_buses and p_nom != 0 and carrier not in @no_redispatch_carriers"
+        g_up = g_up.query(query)
+        g_down = g_down.query(query)
 
         # Compute dispatch limits for the up and down generators
         result_component = unconstrained_result.components[comp.name]
@@ -326,6 +324,7 @@ if __name__ == "__main__":
         renewable_strike_prices,
         interconnector_bid_offer_profile,
         gb_buses,
+        snakemake.params.no_redispatch_carriers,
     )
 
     drop_existing_eur_buses(network)


### PR DESCRIPTION
Closes #201 for the redispatch case (but not allowing it to redispatch). I've left it configurable so that other carriers can also be added in future if desired.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
