### PR TITLE
Fix efficiencies being erroneously set to 100% in network composition

### DIFF
--- a/config/config.gb.2024.yaml
+++ b/config/config.gb.2024.yaml
@@ -193,7 +193,7 @@ fes_costs:
       engine PP: central gas CHP # `direct firing gas` is a better fit but the data is spurious
       engine CHP: central gas CHP
       geothermal PP: geothermal
-      hydrogen turbine PP: central hydrogen CHP
+      hydrogen turbine PP: CCGT
       hydrogen turbine CHP: central hydrogen CHP
       hydrogen fuel cell PP: fuel cell
       nuclear PP: nuclear

--- a/doc/gb-model/release_notes.rst
+++ b/doc/gb-model/release_notes.rst
@@ -13,6 +13,7 @@ Unreleased
 ==========
 
 * Add HiGHS HiPO solver to `pixi` dependencies and to the solver config options.
+* Fix technology efficiencies being erroneously set to 100% in network composition.
 
 v0.2.2 (2026-03-24)
 ===================

--- a/scripts/gb_model/compose_network.py
+++ b/scripts/gb_model/compose_network.py
@@ -182,8 +182,8 @@ def _load_powerplants(
     """
     ppl = pd.read_csv(powerplants_path, index_col="name", dtype={"bus": "str"})
     ppl = ppl[ppl.build_year == year]
-    ppl["max_hours"] = 0  # Initialize max_hours column
-    ppl["efficiency"] = 1.0  # Initialize efficiency column
+    ppl["max_hours"] = ppl.get("max_hours", 0)  # Initialize max_hours column
+    ppl["efficiency"] = ppl.get("efficiency", 1.0)  # Initialize efficiency column
 
     return ppl
 


### PR DESCRIPTION
Fixes issue identified with @euronion in which some technology data was being overwritten at the last moment. It mostly affected hydrogen bus technologies (electrolysis, H2 turbine, etc.).

Also updated the H2 turbine (power plant) to use the CCGT technology data instead of CHP data. I also considered updating the H2 store to salt cavern but see it wouldn't make a difference to efficiency (it isn't included in technology data) so I'm not sure it matters.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
