### PR TITLE
Various docs and workflow fixes for #310

### DIFF
--- a/config/config.gb.2024.yaml
+++ b/config/config.gb.2024.yaml
@@ -103,7 +103,7 @@ renewable:
 conventional:
   nuclear:
     max_annual_capacity_factor: 0.87
-    min_annual_capacity_factor: 0.50
+    min_annual_capacity_factor: 0.70
 
 fes_costs:
   sheet-config:

--- a/doc/gb-model/system_generators.rst
+++ b/doc/gb-model/system_generators.rst
@@ -15,13 +15,14 @@ Overview
 ========
 
 The generation system covers all electricity-producing assets connected to the modelled network, spanning both Great Britain and the surrounding European countries.
-Generators are split into two broad groups:
+Generators are split into broad groups:
 
-- **Conventional generators**: Thermal and nuclear plant (CCGT, OCGT, gas engine, coal, nuclear, oil, waste, biomass, geothermal) that can be dispatched by the model within physical and contractual limits
+- **Conventional generators**: Thermal and nuclear plants (CCGT, OCGT, reciprocating engines, coal, nuclear, oil, waste, biomass, geothermal) that can be dispatched by the model within physical and contractual limits
 - **Renewable generators**: Solar, onshore wind, and offshore wind, whose output is constrained by weather-derived capacity-factor time series
 - **Hydrogen-to-electricity generators**: Fuel cells and hydrogen turbines — documented in :doc:`system_hydrogen`
 
-Additionally, a subset of conventional generators with heat-driven cogeneration duties are subject to simplified *combined heat and power (CHP)* constraints that enforce minimum loading when heat demand is present.
+A subset of conventional generators with heat-driven cogeneration duties are subject to different operating costs and efficiencies, and simplified *combined heat and power (CHP)* constraints that enforce minimum loading when heat demand is present.
+Another subset of conventional generators with carbon capture and storage (CCS) capabilities are also subject to different operating costs.
 
 All generators are modelled as *fixed-capacity*, non-extendable assets — the model dispatches within the capacities supplied and cannot invest in new plant.
 
@@ -39,7 +40,7 @@ The figure below gives a high-level view of the generator data pipeline:
       rankdir=LR;
       node [shape=box, style=filled];
 
-      fes    [label="FES BB1\n(future caps)", fillcolor="#B3D9FF"];
+      fes    [label="FES BB1/ES1\n(future caps)", fillcolor="#B3D9FF"];
       dukes  [label="DUKES 5.11\n(existing caps)", fillcolor="#B3D9FF"];
       entsoe [label="ENTSO-E\n(outage data)", fillcolor="#B3D9FF"];
       costs  [label="FES AS.1/AS.7\n+ PyPSA tech-data\n(costs)", fillcolor="#B3D9FF"];
@@ -61,13 +62,16 @@ The figure below gives a high-level view of the generator data pipeline:
    }
 
 
-FES BB1 — Future Capacity Projections
---------------------------------------
+FES BB1/ES1 — Future Capacity Projections
+-----------------------------------------
 
-The primary source of *future* generator capacities for Great Britain is the NESO **Future Energy Scenarios (FES) 2024** workbook, sheet **BB1 (Building Blocks)**.
+The primary source of *future* generator capacities for Great Britain is the NESO **Future Energy Scenarios (FES) 2024** workbook, sheets **BB1 (Building Blocks)** and **ES1 (Electricity supply data)**.
 
-BB1 provides annual capacity projections (in GW) disaggregated to Grid Supply Points (GSPs) for each FES scenario.
-Carrier and component-set assignment is performed through the ``fes.gb.carrier_mapping`` and ``fes.gb.set_mapping`` dictionaries in the configuration.
+BB1 provides annual capacity projections disaggregated to Grid Supply Points (GSPs) for each FES scenario.
+ES1 provides annual capacity projections for a greater disaggregation of technologies than given in BB1, also for each FES scenario.
+
+The link between ES1 technologies and BB1 building blocks is configured in ``fes.gb.building_block_mapping``.
+The link between ES1 technologies and PyPSA network carrier names is configured in ``fes.gb.carrier_mapping``.
 
 DUKES 5.11 — Existing Infrastructure
 --------------------------------------
@@ -127,29 +131,42 @@ Conventional generators include all thermal plant that can be freely dispatched 
 
 The carriers modelled are:
 
-+---------------------------+---------------------------------+
-| Carrier                   | Notes                           |
-+===========================+=================================+
-| ``CCGT``                  | Combined-cycle gas turbine      |
-+---------------------------+---------------------------------+
-| ``OCGT``                  | Open-cycle gas turbine          |
-+---------------------------+---------------------------------+
-| ``engine``                | Gas reciprocating engine        |
-+---------------------------+---------------------------------+
-| ``nuclear``               | Nuclear (baseload)              |
-+---------------------------+---------------------------------+
-| ``coal``                  | Coal plant                      |
-+---------------------------+---------------------------------+
-| ``oil``                   | Oil-fired plant                 |
-+---------------------------+---------------------------------+
-| ``waste``                 | Waste incineration              |
-+---------------------------+---------------------------------+
-| ``biomass``               | Biomass/bioenergy               |
-+---------------------------+---------------------------------+
-| ``geothermal``            | Geothermal (minor capacity)     |
-+---------------------------+---------------------------------+
+.. list-table::
+    :header-rows: 1
 
-Capacity is set to the FES BB1 projection for the model year, spatially distributed to model regions.
+    * - Carrier
+      - Set options
+      - Description
+    * - ``CCGT``
+      - PP/CHP/CCS
+      - Combined-cycle gas turbine
+    * - ``OCGT``
+      - PP/CHP
+      - Open-cycle gas turbine
+    * - ``engine``
+      - PP
+      - Gas reciprocating engine
+    * - ``nuclear``
+      - PP
+      - Nuclear (baseload)
+    * - ``coal``
+      - PP
+      - Coal plant
+    * - ``oil``
+      - PP
+      - Oil-fired plant
+    * - ``waste``
+      - PP/CHP
+      - Waste incineration
+    * - ``biomass``
+      - PP/CHP/CCS
+      - Biomass/bioenergy
+    * - ``geothermal``
+      - PP
+      - Geothermal (minor capacity)
+
+Component names are the carrier names appended with their set name if it is **not** ``PP``.
+That is, gas CHP plants will be named ``CCGT-CHP``; gas CCS plants ``CCGT-CCS``; standard gas plants ``CCGT``.
 
 .. _generators-renewables:
 
@@ -173,8 +190,8 @@ The renewable carriers are:
       - Onshore wind
     * - ``offwind-dc``
       - Offshore wind (DC-connected)
-    * - ``hydro``
-      - Reservoir hydro
+    * - ``ror``
+      - Run-of-River hydro (no storage reservoir)
 
 .. _generators-chp:
 
@@ -185,7 +202,7 @@ Combined Heat and Power (CHP)
 
 Many conventional carriers (CCGT, biomass, waste, etc.) exist in two variants: pure power plants and CHP units.
 FES BB1 reports some technologies (e.g. "Biomass & Energy Crops (including CHP)", "Waste Incineration (including CHP)", "Non-renewable CHP") as including cogeneration.
-FES ES1 reports the share of the CHP units and pure powerplants for each year for some of these technologies. 
+FES ES1 reports the share of the CHP units and pure powerplants for each year for some of these technologies.
 Based on the SubType of the technologies in ES1, which contain `CHP` as part of the naming, the mapping for the powerplants as `CHP` or `PP` is determined.
 The resulting ``set`` column in the powerplants table therefore determines which fraction of each carrier is subject to CHP constraints — not the carrier itself.
 
@@ -251,15 +268,14 @@ Each generator in the powerplants table is enriched with cost and technical para
 
 1. **FES AS.1**: Provides year-specific fuel costs and VOM for GB-relevant technologies; averaged across scenarios because scenario names change between FES editions
 2. **FES AS.7**: Provides year-specific carbon price (£/tCO₂); averaged across scenarios
-3. **PyPSA technology-data**: Provides capital costs (£/MW), fixed O&M (£/MW/year), efficiency, and lifetime for technologies absent from the FES costing workbook.
-   In the current workflow only **efficiency** is actively used in dispatch runs; the remaining parameters are written to the output for reference only
-4. **Default characteristics**: Fallbacks defined in ``fes_costs.default_characteristics`` ensure all columns exist even when data is missing
+3. **PyPSA technology-data**: Provides efficiency and CO₂ intensity (tCO₂/kWh) for technologies, since this data is absent from the FES workbooks.
+4. **Default characteristics**: Fallbacks defined in ``fes_costs.pypsa_eur_tech_data_defaults`` ensure all PyPSA-Eur technology data exist even when data is missing.
 
 Marginal costs are assembled as:
 
 .. math::
 
-   c_\text{marginal} = \frac{c_\text{fuel}}{\eta} + c_\text{VOM} + c_\text{CO2} \cdot I_\text{CO2}
+   c_\text{marginal} = c_\text{CO2} \cdot I_\text{CO2} \cdot \frac{c_\text{fuel}}{\eta} + c_\text{VOM}
 
 where :math:`\eta` is efficiency, :math:`c_\text{fuel}` thermal price, :math:`c_\text{VOM}` variable O&M, :math:`c_\text{CO2}` carbon price, and :math:`I_\text{CO2}` the CO₂ intensity.
 
@@ -269,22 +285,40 @@ where :math:`\eta` is efficiency, :math:`c_\text{fuel}` thermal price, :math:`c_
 Configuration
 =============
 
+The below configuration snippets are based on the content of ``config/config.gb.2024.yaml``.
+
 Carrier and Set Definitions
 -----------------------------
 
 The carriers included in the model and how they are treated (conventional vs renewable, generator vs store) are controlled by:
-
-From ``config/config.gb.2024.yaml``:
 
 .. literalinclude:: ../../config/config.gb.2024.yaml
    :language: yaml
    :start-after: # [doc:electricity-config-start]
    :end-before: # [doc:electricity-config-end]
 
+FES technology to PyPSA network carrier mapping (GB):
+
+.. literalinclude:: ../../config/config.gb.2024.yaml
+   :language: yaml
+   :start-after: # [doc:gb-generator-storage-start]
+   :end-before: # [doc:gb-generator-storage-end]
+   :prepend: fes.gb:
+
+FES technology to PyPSA network carrier mapping (EUR):
+
+.. literalinclude:: ../../config/config.gb.2024.yaml
+   :language: yaml
+   :start-after: # [doc:eur-generator-storage-start]
+   :end-before: # [doc:eur-generator-storage-end]
+   :prepend: fes.eur:
+
+.. note::
+   We use the dot notation for parent configuration keys.
+   For example, ``fes.gb`` is equivalent to ``fes`` as the top-level key, ``gb`` as the first-level key, then the configuration snippet is at the level below this.
+
 CHP Constraints
 ----------------
-
-From ``config/config.gb.2024.yaml``:
 
 .. literalinclude:: ../../config/config.gb.2024.yaml
    :language: yaml
@@ -293,8 +327,6 @@ From ``config/config.gb.2024.yaml``:
 
 ENTSO-E Unavailability
 -----------------------
-
-From ``config/config.gb.2024.yaml``:
 
 .. literalinclude:: ../../config/config.gb.2024.yaml
    :language: yaml
@@ -331,7 +363,7 @@ The generator system is built through a pipeline implemented in ``rules/gb-model
 1. **Retrieve outage data** (``retrieve_entsoe_unavailability_data``): Fetches ENTSO-E unavailability records for GB over the configured date range, chunked to respect API limits
 2. **Monthly availability fractions** (``generator_monthly_availability_fraction``): Combines outage records with DUKES capacity baselines to produce per-carrier, per-month availability fractions
 3. **Powerplants table** (``create_powerplants_table``): Assembles GSP-level capacity table from FES BB1 (future), DUKES (existing), and European supply data; handles both direct GSP-level data and distribution from Transmission Owner (TO) regional totals
-4. **Cost assignment** (``assign_costs``): Enriches the powerplants table with fuel costs, VOM, carbon costs, capital costs, and technical parameters; produces ``fes_powerplants_inc_tech_data.csv``
+4. **Cost assignment** (``assign_costs``): Enriches the powerplants table with operating costs and technical parameters.
 5. **CHP minimum operation profile** (``create_chp_p_min_pu_profile``): Derives the hourly ``p_min_pu`` time series for CHP generators from the aggregated heat demand dataset
 
 **Network Assembly via PyPSA-Eur Methods**:
@@ -339,9 +371,8 @@ The generator system is built through a pipeline implemented in ``rules/gb-model
 The artefacts produced by ``generators.smk`` are consumed by the ``compose_network`` rule (``rules/gb-model.smk``), which assembles the final PyPSA network.
 In addition to the generator-specific outputs above, ``compose_network`` also receives several standard PyPSA-Eur inputs:
 
-- **Renewable capacity-factor profiles** (``profile_{tech}_clustered.nc``): Hourly ``p_max_pu`` time series for solar, onshore wind, offshore wind, and hydro, produced by the atlite cutout pipeline from ERA5/SARAH reanalysis data
-- **Technology costs CSV** (``costs_{year}.csv``): The PyPSA technology-data cost table for the planning horizon year, used here only to supply efficiency values for conventional carriers not covered by the FES costing workbook
-- **Hydro capacities** (``data/hydro_capacities.csv``): Reservoir and run-of-river hydro installed capacity by country
+- **Renewable capacity-factor profiles** (``profile_{tech}_clustered.nc``): Hourly ``p_max_pu`` time series for solar, onshore wind, offshore wind, and hydro, produced by the atlite cutout pipeline from ERA5/SARAH reanalysis data.
+- **Technology costs CSV** (``costs_{year}.csv``): The PyPSA technology-data cost table for the planning horizon year, used here only because we have to pass it through to standard PyPSA-Eur methods when attaching some generators.
 
 Rather than reimplementing generator attachment logic, ``compose_network`` calls PyPSA-Eur's standard functions from ``scripts/add_electricity.py`` directly:
 
@@ -365,12 +396,11 @@ This hierarchy preserves known regional concentrations (e.g., offshore wind clus
 **Key Assumptions**:
 
 - **No capacity expansion**: All generator capacities are fixed at the FES scenario projections for the modelled year; the optimiser dispatches within these limits
-- **Uniform availability**: Monthly availability fractions are applied uniformly to all generators of the same carrier across all regions
+- **Uniform availability**: Monthly availability fractions are applied uniformly to all generators of the same carrier across all GB regions
 - **CHP heat coupling**: CHPs are constrained to run above a heat-demand-derived floor but are not connected to a separate heat bus; heat demand is satisfied exogenously
 - **Cost averaging**: FES fuel and VOM costs are averaged across scenarios due to naming changes between FES editions; this has a small effect (≤ ~10% for battery VOM) on marginal costs
 - **Infinite fuel supply**: Fuel feedstocks (gas, coal, oil, biomass, etc.) are assumed to be available in unlimited quantities at the modelled marginal cost; no supply constraints or fuel capacity limits are enforced
 - **European generators**: European countries use the PyPSA-Eur conventional generator database; availability fractions are applied outside GB by default (disable via ``entsoe_unavailability.extend_to_eur_regions``), but CHP constraints are not applied outside GB
-
 
 .. seealso::
 

--- a/doc/gb-model/system_overview.rst
+++ b/doc/gb-model/system_overview.rst
@@ -28,14 +28,14 @@ We represent the GB model in PyPSA as follows:
         onwind [label="Onshore Wind", fillcolor="#D8BFD8"];
         offwind [label="Offshore Wind", fillcolor="#D8BFD8"];
         solar [label="Solar", fillcolor="#FFFFCC"];
-        gas [label="Gas plant", fillcolor="#D3D3D3"];
+        gas [label="Gas plant (incl. CHP/CCS)", fillcolor="#D3D3D3"];
         coal [label="Coal plant", fillcolor="#A9A9A9", fontcolor=white];
-        oil [label="Oil plant", fillcolor="#A9A9A9", fontcolor=white];
-        biomass [label="Biomass", fillcolor="#C1FFC1"];
-        waste [label="Waste", fillcolor="#D9A088"];
+        oil [label="Oil plant (incl. CHP)", fillcolor="#A9A9A9", fontcolor=white];
+        biomass [label="Biomass (incl. CHP/CCS)", fillcolor="#C1FFC1"];
+        waste [label="Waste (incl. CHP)", fillcolor="#D9A088"];
         nuclear [label="Nuclear", fillcolor="#ff5364ff"];
         geothermal [label="Geothermal", fillcolor="#ff9844ff"];
-        hydro [label="Hydro", fillcolor="#B3D9FF"];
+        hydro [label="Run-of-River Hydro", fillcolor="#B3D9FF"];
       }
 
       subgraph storage {
@@ -44,6 +44,8 @@ We represent the GB model in PyPSA as follows:
 
         // Storage components (bottom middle)
         battery [label="Battery Storage", fillcolor="#FFFFCC"];
+        liquid-air [label="Liquid Air Storage", fillcolor="#FFFFCC"];
+        compressed-air [label="Compressed Air Storage", fillcolor="#FFFFCC"];
         PHS [label="Pumped Hydro Storage", fillcolor="#FFFFCC"];
       }
       subgraph hydrogen {
@@ -103,6 +105,8 @@ We represent the GB model in PyPSA as follows:
       // Storage connections
       battery -> AC_bus [dir=both, label="charge/discharge"];
       PHS -> AC_bus [dir=both, label="charge/discharge"];
+      liquid-air -> AC_bus [dir=both, label="charge/discharge"];
+      compressed-air -> AC_bus [dir=both, label="charge/discharge"];
 
       // Hydrogen connections
       AC_bus -> h2_bus [label="Electrolysis"];
@@ -224,9 +228,8 @@ These generators are tagged separately based on input data and have an additiona
 Storage
 -------
 
-There are three primary energy storage technologies defined in the model: pumped hydropower (``PHS``), utility-scale batteries (``battery``), and hydrogen storage.
+There are five primary energy storage technologies defined in the model: pumped hydropower (``PHS``), utility-scale batteries (``battery``), liquid-/compressed-air storage (``liquid-air`` / ``compressed-air``) and hydrogen storage.
 Pumped hydropower and batteries have a maximum number of hours they can store energy for which, when combined with their discharge/charge capacity, defines their reservoir capacity.
-In general, we expect pumped hydro and batteries to cycle on short timescales and their max hours reflect this.
 
 .. seealso::
    :ref:`system-hydrogen`, :ref:`system-storage`

--- a/doc/gb-model/system_storage.rst
+++ b/doc/gb-model/system_storage.rst
@@ -35,7 +35,7 @@ The figure below gives a high-level view of the storage data pipeline:
    digraph {
       rankdir=LR;
       node [shape=box, style=filled];
-      es1        [label="FES ES2\n(storage (dis)charge capacity\n& energy capacity)", fillcolor="#B3D9FF"];
+      es1        [label="FES ES1\n(storage (dis)charge capacity\n& energy capacity)", fillcolor="#B3D9FF"];
       fes_bb1    [label="FES BB1\n(battery p_nom,\nPHS capacity)", fillcolor="#B3D9FF"];
       dukes      [label="DUKES 5.11\n(PHS existing caps)", fillcolor="#B3D9FF"];
       es2        [label="FES ES2\n(EUR battery p_nom)", fillcolor="#B3D9FF"];
@@ -60,7 +60,7 @@ FES ES1 — Storage Max Hours
 
 Storage *(dis)charge* (``p_nom``, in MW) and *energy* capacity (``e_nom``, in GWh) for Great Britain is drawn from the NESO **Future Energy Scenarios (FES) 2024** workbook, sheet **ES1 (Electricity supply)**.
 
-Together, these can be used to define the maximum number of hours that a storage vessel could discharge for: :math:`\text{max\_hours} = e_\text{nom}/p_\text{nom}`.
+Together, these can be used to define the maximum number of hours that a storage vessel could discharge for: :math:`\text{max_hours} = e_\text{nom}/p_\text{nom}`.
 
 This is then used in defining the technologies in PyPSA since ``StorageUnit`` component energy capacity is defined by its ``max_hours``.
 
@@ -106,20 +106,20 @@ Hydrogen storage is documented separately in :doc:`system_hydrogen`.
 
 For each of these components, charge / discharge efficiency is calculated based on their
 .. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :widths: 20 26 27 27
+    :header-rows: 1
+    :stub-columns: 1
+    :widths: 20 26 27 27
 
-   * - Attribute
-     - Battery
-     - PHS
-     - Compressed air
-     - Liquid air
-   * - **Carrier**
-     - ``battery``
-     - ``PHS``
-     - ``compressed-air``
-     - ``liquid-air``
+    * - Attribute
+      - Battery
+      - PHS
+      - Compressed air
+      - Liquid air
+    * - **Carrier**
+      - ``battery``
+      - ``PHS``
+      - ``compressed-air``
+      - ``liquid-air``
 
 .. _storage-config:
 
@@ -132,7 +132,7 @@ FES technology to PyPSA network carrier mapping (GB):
    :language: yaml
    :start-after: # [doc:gb-generator-storage-start]
    :end-before: # [doc:gb-generator-storage-end]
-   :prepend: fes:\n  gb:
+   :prepend: fes.gb:
 
 FES technology to PyPSA network carrier mapping (EUR):
 
@@ -140,7 +140,11 @@ FES technology to PyPSA network carrier mapping (EUR):
    :language: yaml
    :start-after: # [doc:eur-generator-storage-start]
    :end-before: # [doc:eur-generator-storage-end]
-   :prepend: fes:\n  eur:
+   :prepend: fes.eur:
+
+.. note::
+   We use the dot notation for parent configuration keys.
+   For example, ``fes.gb`` is equivalent to ``fes`` as the top-level key, ``gb`` as the first-level key, then the configuration snippet is at the level below this.
 
 PyPSA network carrier to PyPSA-Eur technology data mapping:
 

--- a/scripts/gb_model/compose_network.py
+++ b/scripts/gb_model/compose_network.py
@@ -1094,7 +1094,7 @@ def add_H2(
     )
 
     if not (
-        h2_gen := ppl.query("carrier in ['hydrogen turbine', 'hydrogen fuel cell']")
+        h2_gen := ppl.query("carrier in ['hydrogen-turbine', 'hydrogen-fuel-cell']")
     ).empty:
         h2_gen_buses = h2_gen.bus.unique()
         n.add(
@@ -1125,7 +1125,7 @@ def add_H2(
             p_nom=np.inf,
         )
 
-    if not (fuel_cells := ppl.query("carrier == 'hydrogen fuel cell'")).empty:
+    if not (fuel_cells := ppl.query("carrier == 'hydrogen-fuel-cell'")).empty:
         n.add("Carrier", "H2 fuel cell")
         n.add(
             "Link",
@@ -1140,7 +1140,7 @@ def add_H2(
             lifetime=fuel_cells.lifetime,
         )
 
-    if not (turbines := ppl.query("carrier == 'hydrogen turbine'")).empty:
+    if not (turbines := ppl.query("carrier == 'hydrogen-turbine'")).empty:
         n.add("Carrier", "H2 Turbine")
         n.add(
             "Link",

--- a/scripts/gb_model/generators/assign_costs.py
+++ b/scripts/gb_model/generators/assign_costs.py
@@ -243,8 +243,7 @@ def _calculate_marginal_costs(
     return (
         df["VOM"]
         .fillna(0)
-        .add(df["fuel"].add(carbon_tax).fillna(0))
-        .div(df["efficiency"])
+        .add((df["fuel"].add(carbon_tax).fillna(0)).div(df["efficiency"]))
         .fillna(0)
     )
 


### PR DESCRIPTION
A few fixes on reviewing two solved networks from before and after #310.
 
## Changes proposed in this Pull Request

- more strict nuclear lower bound
- fix hydrogen turbine and fuel cell carrier name expectations
- docs updates

## Differences between pre-#310 and now:

### Capacities
```
                                                                     old           new          diff
component   carrier                                                                                 
StorageUnit hydro                                           1.431080e+05           NaN -143108.00120
            Battery Storage                                 1.316844e+05           NaN -131684.40900
Generator   biomass                                         3.941461e+04  3.812796e+04   -1286.64900
Link        H2 Turbine                                      1.199227e+05  1.199227e+05      -0.00626
Store       H2 Store                                        5.200000e+06  5.200000e+06       0.00000
            EV V2G                                          4.967967e+06  4.967967e+06       0.00000
            EV DSR                                          4.119742e+06  4.119742e+06       0.00000
            Baseline Electricity (Residential) DSR          2.003957e+05  2.003957e+05       0.00000
            Baseline Electricity (I&C) DSR                  1.528319e+05  1.528319e+05       0.00000
Link        I&C Heat DSR reverse                            1.652856e+04  1.652856e+04       0.00000
StorageUnit PHS                                             6.796030e+04  6.796030e+04       0.00000
Store       Residential Heat DSR                            2.029792e+06  2.029792e+06       0.00000
Link        Transmission-level + T&D losses unmanaged load  1.578100e+04  1.578100e+04       0.00000
            Residential Heat unmanaged load                 3.116816e+05  3.116816e+05       0.00000
            Residential Heat DSR shift                      8.825182e+04  8.825182e+04       0.00000
            Residential Heat DSR reverse                    8.825182e+04  8.825182e+04       0.00000
            I&C Heat unmanaged load                         1.933884e+05  1.933884e+05       0.00000
            I&C Heat DSR shift                              1.652856e+04  1.652856e+04       0.00000
Store       I&C Heat DSR                                    3.801569e+05  3.801569e+05       0.00000
Generator   CCGT                                            1.267345e+05  1.267345e+05       0.00000
Link        H2 Electrolysis                                 1.243233e+04  1.243233e+04       0.00000
Generator   waste                                           3.437037e+03  3.437037e+03       0.00000
            nuclear                                         7.283800e+04  7.283800e+04       0.00000
            oil                                             1.491717e+03  1.491717e+03       0.00000
            onwind                                          5.207977e+05  5.207977e+05       0.00000
            solar                                           8.869028e+05  8.869028e+05       0.00000
Link        EV unmanaged load                               2.926996e+05  2.926996e+05       0.00000
Line        AC                                              5.100198e+09  5.100198e+09       0.00000
Link        Baseline Electricity (I&C) DSR shift            3.820797e+04  3.820797e+04       0.00000
            Baseline Electricity (I&C) DSR reverse          3.820797e+04  3.820797e+04       0.00000
            Baseline Electricity (Residential) DSR shift    5.009893e+04  5.009893e+04       0.00000
            Baseline Electricity unmanaged load             4.100955e+05  4.100955e+05       0.00000
            DC                                              1.000379e+08  1.000379e+08       0.00000
            EV DSR reverse                                  1.791192e+05  1.791192e+05       0.00000
            EV DSR shift                                    1.791192e+05  1.791192e+05       0.00000
            EV V2G                                          1.391587e+06  1.391587e+06       0.00000
            Baseline Electricity (Residential) DSR reverse  5.009893e+04  5.009893e+04       0.00000
Generator   coal                                            1.039154e+04  1.039154e+04       0.00000
            offwind-dc                                      3.204590e+05  3.205468e+05      87.78835
            geothermal                                      1.100000e+01  1.297645e+03    1286.64500
StorageUnit compressed-air                                           NaN  3.503294e+03    3503.29400
            liquid-air                                               NaN  4.354700e+03    4354.70000
            battery                                                  NaN  1.316844e+05  131684.40900
Generator   ror                                                      NaN  1.431080e+05  143108.01020
            Load Shedding                                            inf           inf           NaN
            purchased H2                                             inf           inf           NaN
Link        H2                                                       inf           inf           NaN
```

As expected, most capacities do not change. Main changes are:
- "Battery Storage" -> "battery" carrier name
- "other renewables" -> geothermal, not biomass
- "hydro" -> "ror" as we have changed the hydro carrier to run-of-river
- Addition of liquid-/compressed-air storage

### Marginal costs

Generators:
```
network                   new         old          diff
carrier       set                                      
waste         CHP    3.145000  103.673069 -1.005281e+02
              PP     3.145000   65.758597 -6.261360e+01
geothermal    PP     0.000000   10.561818 -1.056182e+01
CCGT          PP    67.993611   67.993611 -1.421085e-14
biomass       PP    26.812941   26.812941  0.000000e+00
coal          PP   103.760232  103.760232  0.000000e+00
nuclear       PP     5.950000    5.950000  0.000000e+00
offwind-dc           0.000000    0.000000  0.000000e+00
onwind               0.000000    0.000000  0.000000e+00
purchased H2        26.992141   26.992141  0.000000e+00
ror                  0.000000         NaN  0.000000e+00
solar                0.000000    0.000000  0.000000e+00
Load Shedding      152.517345  152.517345  2.842171e-14
oil           PP   151.517345  151.517345  2.842171e-14
biomass       CHP   44.931402   29.957941  1.497346e+01
CCGT          CHP   95.460844   68.461111  2.699973e+01
biomass       CCS   47.028048         NaN  4.702805e+01
CCGT          CCS   59.311678         NaN  5.931168e+01
```

Storage:
```
network               new       old      diff
carrier                                      
Battery Storage       NaN  3.216665 -3.216665
PHS              0.000000  0.000000  0.000000
hydro                 NaN  0.000000  0.000000
compressed-air   1.747237       NaN  1.747237
liquid-air       1.786248       NaN  1.786248
battery          3.216665       NaN  3.216665
```

Changes: 
- differentiation of CHP is clearer. 
- New CCS technology sets
- Geothermal loses its costs ("other renewables" have no operating costs)
- waste loses lots of its costs (no longer accounting for fuel costs). It feels like waste feedstock should be cost-free, but perhaps we should reinstate fuel pellet costs as before.

### Optimal annual supply

Since costs (and some capacities) change, final dispatch decisions do, too:
```
                                                                     old           new          diff
component   carrier                                                                                 
StorageUnit hydro                                           4.355583e+08           NaN -4.355583e+08
Link        DC                                              3.919962e+08  3.205002e+08 -7.149599e+07
Generator   offwind-dc                                      1.542316e+09  1.501811e+09 -4.050462e+07
            nuclear                                         4.810345e+08  4.466426e+08 -3.439185e+07
            onwind                                          9.968458e+08  9.652410e+08 -3.160475e+07
StorageUnit Battery Storage                                 1.576725e+07           NaN -1.576725e+07
Link        EV V2G                                          1.921595e+09  1.905950e+09 -1.564526e+07
Generator   solar                                           9.764733e+08  9.609021e+08 -1.557126e+07
Link        EV unmanaged load                               2.252254e+09  2.244432e+09 -7.822628e+06
Store       EV V2G                                          3.867406e+08  3.795276e+08 -7.212936e+06
            H2 Store                                        2.483023e+07  1.986554e+07 -4.964689e+06
Link        EV DSR shift                                    6.280673e+08  6.244318e+08 -3.635512e+06
            EV DSR reverse                                  6.280673e+08  6.244318e+08 -3.635512e+06
Store       EV DSR                                          2.131749e+08  2.095808e+08 -3.594158e+06
Link        H2                                              6.138477e+06  3.094678e+06 -3.043799e+06
            H2 Electrolysis                                 4.957848e+07  4.653468e+07 -3.043799e+06
Store       Residential Heat DSR                            1.310019e+08  1.290844e+08 -1.917468e+06
Link        Residential Heat DSR reverse                    3.873618e+08  3.865887e+08 -7.731143e+05
            Residential Heat DSR shift                      3.873618e+08  3.865887e+08 -7.731142e+05
            I&C Heat DSR reverse                            7.245016e+07  7.177876e+07 -6.714024e+05
            I&C Heat DSR shift                              7.245016e+07  7.177876e+07 -6.714022e+05
Store       Baseline Electricity (Residential) DSR          1.936695e+07  1.888008e+07 -4.868792e+05
            Baseline Electricity (I&C) DSR                  1.197229e+07  1.193373e+07 -3.856948e+04
Link        Transmission-level + T&D losses unmanaged load  1.180039e+08  1.180039e+08  0.000000e+00
            I&C Heat unmanaged load                         3.804819e+08  3.804819e+08  1.523600e-01
            Residential Heat unmanaged load                 6.348570e+08  6.348570e+08  1.720500e-01
            Baseline Electricity unmanaged load             2.429723e+09  2.429723e+09  3.060799e-01
            Baseline Electricity (I&C) DSR reverse          3.420725e+07  3.444615e+07  2.389057e+05
            Baseline Electricity (I&C) DSR shift            3.420725e+07  3.444615e+07  2.389061e+05
            Baseline Electricity (Residential) DSR reverse  5.371141e+07  5.396572e+07  2.543142e+05
            Baseline Electricity (Residential) DSR shift    5.371141e+07  5.396572e+07  2.543146e+05
Store       I&C Heat DSR                                    3.061978e+07  3.088240e+07  2.626198e+05
StorageUnit liquid-air                                               NaN  2.675279e+05  2.675279e+05
Generator   oil                                             3.410930e+05  6.217516e+05  2.806586e+05
StorageUnit compressed-air                                           NaN  8.201550e+05  8.201550e+05
Generator   coal                                            5.558459e+06  9.454616e+06  3.896157e+06
            waste                                           6.995863e+06  1.146127e+07  4.465402e+06
Link        H2 Turbine                                      1.863646e+08  1.917247e+08  5.360121e+06
Generator   geothermal                                      1.760395e+04  6.035237e+06  6.017634e+06
StorageUnit battery                                                  NaN  1.100138e+07  1.100138e+07
Generator   biomass                                         1.299007e+08  1.413721e+08  1.147140e+07
            purchased H2                                    3.124335e+08  3.247802e+08  1.234666e+07
StorageUnit PHS                                             3.258721e+07  4.943827e+07  1.685106e+07
Generator   Load Shedding                                   1.086116e+07  3.736235e+07  2.650118e+07
            CCGT                                            1.561954e+08  2.058069e+08  4.961151e+07
Line        AC                                              1.228752e+12  1.229066e+12  3.147260e+08
Generator   ror                                                      NaN  4.604522e+08  4.604522e+08
```

Some relatively big changes here. I can't account for every change. I think we get more load shedding because we use RoR instead of reservoir hydro, so that source of storage in European countries is lost. I'm not sure why we get less nuclear/wind dispatch; it doesn't seem to be logical for it to curtail this generation further when there is load shedding at other times.

### Withdrawals

```
                                                                     old           new          diff
component   carrier                                                                                 
Link        DC                                              3.919962e+08  3.345704e+08 -5.742582e+07
StorageUnit Battery Storage                                 1.576725e+07           NaN -1.576725e+07
Link        EV DSR shift                                    6.280673e+08  6.235520e+08 -4.515282e+06
            EV DSR reverse                                  6.280673e+08  6.235520e+08 -4.515282e+06
            EV V2G                                          1.921595e+09  1.918133e+09 -3.462496e+06
            H2 Electrolysis                                 5.944321e+07  5.715698e+07 -2.286230e+06
            H2                                              6.138477e+06  4.231652e+06 -1.906826e+06
            EV unmanaged load                               2.252254e+09  2.250523e+09 -1.731248e+06
Store       H2 Store                                        2.483023e+07  2.326142e+07 -1.568817e+06
Link        Residential Heat DSR reverse                    3.873618e+08  3.859792e+08 -1.382590e+06
            Residential Heat DSR shift                      3.873618e+08  3.859792e+08 -1.382590e+06
Store       EV DSR                                          2.131749e+08  2.118447e+08 -1.330222e+06
            EV V2G                                          3.867406e+08  3.856405e+08 -1.100091e+06
            Baseline Electricity (Residential) DSR          1.936695e+07  1.858620e+07 -7.807554e+05
Link        I&C Heat DSR reverse                            7.245016e+07  7.200192e+07 -4.482384e+05
            I&C Heat DSR shift                              7.245016e+07  7.200192e+07 -4.482383e+05
Store       Baseline Electricity (I&C) DSR                  1.197229e+07  1.176643e+07 -2.058643e+05
Link        Transmission-level + T&D losses unmanaged load  1.180039e+08  1.180039e+08  0.000000e+00
Load        AC                                              2.580000e+06  2.580000e+06  0.000000e+00
            Baseline Electricity                            2.429723e+09  2.429723e+09  0.000000e+00
            EV                                              1.291457e+09  1.291457e+09  0.000000e+00
            H2                                              4.086000e+07  4.086000e+07  0.000000e+00
            I&C Heat                                        3.804819e+08  3.804819e+08  0.000000e+00
            Residential Heat                                6.348570e+08  6.348570e+08  0.000000e+00
            Transmission-level + T&D losses                 1.180039e+08  1.180039e+08  0.000000e+00
Link        I&C Heat unmanaged load                         3.804819e+08  3.804819e+08  1.337100e-01
            Residential Heat unmanaged load                 6.348570e+08  6.348570e+08  1.547199e-01
            Baseline Electricity unmanaged load             2.429723e+09  2.429723e+09  2.597499e-01
            Baseline Electricity (I&C) DSR reverse          3.420725e+07  3.439896e+07  1.917090e+05
            Baseline Electricity (I&C) DSR shift            3.420725e+07  3.439895e+07  1.917093e+05
            Baseline Electricity (Residential) DSR reverse  5.371141e+07  5.396065e+07  2.492404e+05
            Baseline Electricity (Residential) DSR shift    5.371141e+07  5.396065e+07  2.492407e+05
StorageUnit liquid-air                                               NaN  9.039022e+05  9.039022e+05
Store       I&C Heat DSR                                    3.061978e+07  3.238022e+07  1.760441e+06
StorageUnit compressed-air                                           NaN  2.027542e+06  2.027542e+06
Store       Residential Heat DSR                            1.310019e+08  1.334409e+08  2.439064e+06
Link        H2 Turbine                                      3.185720e+08  3.290121e+08  1.044012e+07
StorageUnit battery                                                  NaN  1.588642e+07  1.588642e+07
            PHS                                             4.708420e+07  7.221564e+07  2.513144e+07
Line        AC                                              1.228752e+12  1.229025e+12  2.736112e+08
```

There is less EV/Heat DSR but more electricity ToUT DSR, but on balance there is less DSR being leveraged - why? Unclear. I don't think it is a bug, just the result of increased flexible dispatch (CCGT) and decreased inflexible dispatch (nuclear/wind).
 
## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add -f gb-model <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.GB.yaml`.
- [ ] Changes in configuration options are documented in `doc/gb-model/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/gb-model/data_sources.rst`.
- [ ] A release note `doc/gb-model/release_notes.rst` is added.
